### PR TITLE
fix: typos in documentation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Users do not need to understand what's the ocalls during this process.
 
 ## Supported Environment
 
-| Operator System  | Intel SGX SDK | Rust Toolchain     | Status |
+| Operating System  | Intel SGX SDK | Rust Toolchain     | Status |
 | ---------------- | ------------- | ------------------ | ------ |
 | Ubuntu 20.04 LTS | 2.24          | nightly-2024-02-01 | ✅      |
 | Ubuntu 22.04 LTS | 2.24          | nightly-2024-02-01 | ✅      |


### PR DESCRIPTION
Corrected `Operator System` to `Operating System`