### PR TITLE
Fix retval order

### DIFF
--- a/src/app/enclave.rs
+++ b/src/app/enclave.rs
@@ -73,7 +73,7 @@ macro_rules! enclave {
 
         extern "C" {
             $(
-            fn $fn_name(eid: $crate::types::EnclaveId, $($arg_name: $arg_type,)* retval: *mut $crate::types::SgxStatus)  $(-> $ret_type)?;
+            fn $fn_name(eid: $crate::types::EnclaveId, retval: *mut $crate::types::SgxStatus, $($arg_name: $arg_type,)*)  $(-> $ret_type)?;
             )*
         }
 
@@ -93,7 +93,7 @@ macro_rules! enclave {
                     let eid = self.0.eid().map_err(AppError::OnEcall(&stringify!($fn_name)))?;
                     let mut retval = $crate::types::SgxStatus::Success;
                     let ret = unsafe {
-                        $fn_name(eid, $($arg_name,)* &mut retval)
+                        $fn_name(eid, &mut retval, $($arg_name,)*)
                     };
                     if retval != $crate::types::SgxStatus::Success {
                         return Err(retval).map_err(AppError::OnEcall(&stringify!($fn_name)));

--- a/src/app/untrusted.rs
+++ b/src/app/untrusted.rs
@@ -12,7 +12,7 @@ macro_rules! enclave {
 
         extern "C" {
             $(
-            fn $fn_name($($arg_name: $arg_type,)* retval: *mut $crate::types::SgxStatus)  $(-> $ret_type)?;
+            fn $fn_name(retval: *mut $crate::types::SgxStatus, $($arg_name: $arg_type,)*)  $(-> $ret_type)?;
             )*
         }
 
@@ -28,7 +28,7 @@ macro_rules! enclave {
                     eprintln!("{}", "=".repeat(80));
                     let mut retval = $crate::types::SgxStatus::Success;
                     let ret = unsafe {
-                        $fn_name($($arg_name,)* &mut retval)
+                        $fn_name(&mut retval, $($arg_name,)*)
                     };
                     if retval != $crate::types::SgxStatus::Success {
                         return Err(retval.into());


### PR DESCRIPTION
Normally, when invoking an ECALL, we first need to line up two arguments, `eid` and `retval`, to obtain the result of the ECALL from an untrusted environment. However, the current definition of the macro `enclave!` does not support using ECALL appropriately, effectively rendering the first argument other than `eid` and `retval` unusable within the enclave.

For example, consider the following function defined within the trusted block of `enclave.edl`:

```
public sgx_status_t ecall_test(
    int a,
    int b
);
```

After macro expansion, the generated code running in the untrusted environment would incorrectly attempt to invoke this function as `ecall_test(eid, a, b, retval)`. The correct invocation should be `ecall_test(eid, retval, a, b)`.

This issue did not manifest previously when ECALLs did not include any user-defined arguments, resulting in invocations such as `f(eid, retval)`.

These suggested changes have been validated in my project based on sgx-scaffold.

