### PR TITLE
chore: update `serde` to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ sgx_unwind = ["dep:sgx_unwind"]
 
 [dependencies]
 cc = { version = "1.1.5" }
-serde = { version = "=1.0.219", features = ["derive"] }
+serde = { version = "=1.0.215", features = ["derive"] }
 serde_json = "1"
 ctor = "0.2"
 automata-build-script = { path = "build-script", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ sgx_unwind = ["dep:sgx_unwind"]
 
 [dependencies]
 cc = { version = "1.1.5" }
-serde = { version = "=1.0.197", features = ["derive"] }
+serde = { version = "=1.0.219", features = ["derive"] }
 serde_json = "1"
 ctor = "0.2"
 automata-build-script = { path = "build-script", optional = true }


### PR DESCRIPTION
Small PR to update `serde` to latest version (compiles a-ok) as given the age of these crates, their dependencies are starting to clash with other crates with newer sets of dependencies. 