### PR TITLE
Fix typo in compatibility mode warning message

### DIFF
--- a/build-script/src/std_app.rs
+++ b/build-script/src/std_app.rs
@@ -35,7 +35,7 @@ pub fn build_std_app() {
         }
         None => {
             println!(
-                "cargo:warning={} is intended to build from `cargo sgx build`, please try install it by `cargo install cargo-sgx`, now will goto compatibility mode (rebuild everytime)",
+                "cargo:warning={} is intended to build from `cargo sgx build`, please try install it by `cargo install cargo-sgx`, now will goto compatibility mode (rebuild every time)",
                 pkg_name
             );
             // println!("cargo:rerun-if-env-changed=CARGO_BUILD");


### PR DESCRIPTION


Description:  
This pull request corrects a minor typo in the build warning message within std_app.rs, changing "everytime" to "every time" for improved clarity and professionalism. 